### PR TITLE
Allow extending this module in intermediate libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,11 @@ This is a tslint rule that warns about focussed Jasmine tests - fdescribe and fi
 
 ## Usage
 * Install with: `npm install tslint-defocus --save-dev`
-* Add the rule to your `.tslint.json` file:
+* Extend this package in your `.tslint.json` file, e.g.:
 ```
-  "rulesDirectory": "./node_modules/tslint-defocus/dist",
+  "extends": [
+    "tslint-defocus"
+  ],
   "rules": {
     "defocus": true,
     ...

--- a/index.js
+++ b/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+    rulesDirectory: "dist",
+};

--- a/package.json
+++ b/package.json
@@ -23,10 +23,9 @@
     "url": "https://github.com/Sergiioo/tslint-defocus/issues"
   },
   "license": "MIT",
-  "version": "0.0.0-20",
+  "version": "0.0.0-21",
   "dependencies": {
-    "es6-shim": "^0.35.0",
-    "typescript": "^2.4.1"
+    "es6-shim": "^0.35.0"
   },
   "devDependencies": {
     "@types/chai": "^4.0.1",
@@ -43,7 +42,8 @@
     "run-sequence": "^2.0.0"
   },
   "peerDependencies": {
-    "tslint": "^5.4.3"
+    "tslint": "^5.4.3",
+    "typescript": "^2.4.1"
   },
   "scripts": {
     "clean": "gulp clean",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/Sergiioo/tslint-defocus/issues"
   },
   "license": "MIT",
-  "version": "2.0.4-0",
+  "version": "0.0.0-20",
   "dependencies": {
     "es6-shim": "^0.35.0",
     "typescript": "^2.4.1"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/Sergiioo/tslint-defocus/issues"
   },
   "license": "MIT",
-  "version": "0.0.0-21",
+  "version": "0.0.0-22",
   "dependencies": {
     "es6-shim": "^0.35.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "tslint-defocus",
+  "name": "@ftr/tslint-defocus",
   "description": "tslint rule to warn about focussed test cases",
   "author": {
     "name": "Sergio Annecchiarico",
@@ -23,7 +23,7 @@
     "url": "https://github.com/Sergiioo/tslint-defocus/issues"
   },
   "license": "MIT",
-  "version": "2.0.3",
+  "version": "2.0.4-0",
   "dependencies": {
     "es6-shim": "^0.35.0",
     "typescript": "^2.4.1"
@@ -41,7 +41,7 @@
     "istanbul": "^0.4.5",
     "mocha": "^3.1.0",
     "run-sequence": "^2.0.0"
-  }, 
+  },
   "peerDependencies": {
     "tslint": "^5.4.3"
   },

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   "version": "2.0.3",
   "dependencies": {
     "es6-shim": "^0.35.0",
-    "tslint": "^5.4.3",
     "typescript": "^2.4.1"
   },
   "devDependencies": {
@@ -42,6 +41,9 @@
     "istanbul": "^0.4.5",
     "mocha": "^3.1.0",
     "run-sequence": "^2.0.0"
+  }, 
+  "peerDependencies": {
+    "tslint": "^5.4.3"
   },
   "scripts": {
     "clean": "gulp clean",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,9 @@
     "gulp-typescript": "^3.0.0",
     "istanbul": "^0.4.5",
     "mocha": "^3.1.0",
-    "run-sequence": "^2.0.0"
+    "run-sequence": "^2.0.0",
+    "tslint": "^5.4.3",
+    "typescript": "^2.4.1"
   },
   "peerDependencies": {
     "tslint": "^5.4.3",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/Sergiioo/tslint-defocus/issues"
   },
   "license": "MIT",
-  "version": "0.0.0-22",
+  "version": "2.0.3",
   "dependencies": {
     "es6-shim": "^0.35.0"
   },


### PR DESCRIPTION
* This package, `tslint-defocus`, provides TS Lint rules to disallow fdescribe/fit statements
* This PR is within our fork of the repo (which I will raise against the source repo in due time; EDIT: raised here https://github.com/Sergiioo/tslint-defocus/pull/6), and makes some fixes required for our setup (i.e. move some dependencies to peer dependencies so it works in our monorepo, and change the export pattern to work with code-standards)